### PR TITLE
Fixed logging to console so it works in IE

### DIFF
--- a/examples/singlepage/app/app.js
+++ b/examples/singlepage/app/app.js
@@ -83,7 +83,7 @@ Ext.application({
             },
             
             beforedispatch: function(token, match, params) {
-                console.log('beforedispatch ' + token);
+                Ext.log('beforedispatch ' + token);
             },
             
             /**


### PR DESCRIPTION
The current code console.log does not work in IE 8. It works though if Ext.log is used for logging instead.
